### PR TITLE
[IMP] l10n_es_ticketbai*: send S on surcharge_or_simplified_regime

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -20,7 +20,10 @@ class AccountMove(models.Model):
         context = self.env.context
         invoice_type = context.get("move_type", context.get("default_move_type"))
         if invoice_type in ["out_invoice", "out_refund"]:
-            key = self.env["tbai.vat.regime.key"].search([("code", "=", "01")], limit=1)
+            code = "01"
+            if self.env.user.company_id.tbai_vat_regime_simplified:
+                code = "52"
+            key = self.env["tbai.vat.regime.key"].search([("code", "=", code)], limit=1)
             return key
 
     tbai_enabled = fields.Boolean(related="company_id.tbai_enabled", readonly=True)
@@ -387,8 +390,12 @@ class AccountMove(models.Model):
                 )
             )
         if simplified_regime_key:
-            # Taxes in simplified regime, not surchage
-            vals["vat_regime_key"] = "51"
+            if self.company_id.tbai_vat_regime_simplified:
+                # Taxes in simplified regime, not surchage
+                vals["vat_regime_key"] = "52"
+            else:
+                # Taxes in surchage regime, not simplified
+                vals["vat_regime_key"] = "51"
         vals["tbai_tax_ids"] = taxes
         return vals
 

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice_tax.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice_tax.py
@@ -257,7 +257,7 @@ class TicketBaiTax(models.Model):
             if (
                 record.is_subject_to
                 and not record.is_exempted
-                and record.tbai_invoice_id.company_id.tbai_vat_regime_simplified
+                and record.tbai_invoice_id.vat_regime_key == "52"
                 and (
                     not record.surcharge_or_simplified_regime
                     or record.surcharge_or_simplified_regime

--- a/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
@@ -195,7 +195,11 @@ odoo.define("l10n_es_ticketbai_pos.tbai_models", function (require) {
                 vatLinesJson.forEach(function (vatLineJson) {
                     var vatLine = vatLineJson[2];
                     if (vatLine.tax.tbai_vat_regime_simplified) {
-                        self.vat_regime_key = "51";
+                        if (company.tbai_vat_regime_simplified) {
+                            self.vat_regime_key = "52";  // Simplified
+                        } else {
+                            self.vat_regime_key = "51";  // Surcharge
+                        }
                     }
                 });
             }


### PR DESCRIPTION
https://www.gipuzkoa.eus/es/web/ogasuna/-/noiz-erabili-behar-da-52-erregimen-erraztuko-eragiketak-gakoa-bezaren-araudi-bereziaren-eta-zerga-garrantzia-duten-eragiketak-eremuan-

Por lo que he visto la clave 52 es para las compañias en regimen simplificado y la clave 51 para las que son de recargo de equivalencia.

Cuando envío con la clave 51, me indica lo siguiente:
![image](https://github.com/Comunitea/l10n-spain/assets/2323616/a212bdc7-69bc-4cc8-90b2-b9b859163a0c)